### PR TITLE
步驟12

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,6 @@
  *= require_tree .
  *= require_self
  */
+.field_with_errors { 
+  display: inline 
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,7 +15,7 @@ class TasksController < ApplicationController
     if @task.save
       redirect_to tasks_path, notice: I18n.t('message.create_success')
     else
-      render new, notice: I18n.t('error.check_input_data')
+      render :new
     end
   end
 
@@ -26,7 +26,7 @@ class TasksController < ApplicationController
     if @task.update(task_params)
       redirect_to tasks_path, notice: I18n.t('message.update_success')
     else
-      render edit, notice: I18n.t('error.check_input_data')
+      render :edit
     end
   end
 
@@ -34,7 +34,7 @@ class TasksController < ApplicationController
     if @task.destroy
       redirect_to tasks_path, notice: I18n.t('message.delete_success')
     else
-      render edit, notice: I18n.t('error.try_again')
+      render :edit
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,3 @@
 class Task < ApplicationRecord
+  validates :title, presence: true
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,4 +1,11 @@
 <%= form_for(task) do |f| %>
+  <% if task.errors.any? %>
+    <ul>
+      <% task.errors.full_messages.each do |message| %>
+      <li><%= message  %></li>
+      <% end %>
+    </ul>                  
+  <% end %>
   <%= f.label :title, t('activerecord.attributes.task.title') %>
   <%= f.text_field :title %>
   <%= f.label :content, t('activerecord.attributes.task.content') %>

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -15,6 +15,12 @@ zh-TW:
         content: "任務內容"
     models:
       task: "任務"
+    errors:
+      models:
+        task:
+          attributes:
+            title:
+              blank: "不可為空"
   action:
     create: "新增"
     edit: "編輯"

--- a/db/migrate/20200630070529_change_task_title_not_null.rb
+++ b/db/migrate/20200630070529_change_task_title_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeTaskTitleNotNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :tasks, :title, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_20_154631) do
+ActiveRecord::Schema.define(version: 2020_06_30_070529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "title"
+    t.string "title", null: false
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,19 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  let(:task) { create(:task) }
+  let(:task) { build(:task) }
 
   before do
     task
   end
 
   it "it contain title & content" do
-    task.title
-    task.content
+    expect(task.title).to be_present
+    expect(task.content).to be_present
   end
 
   it "is not valid without a title" do
     task.title = nil
     expect(task).to_not be_valid
+    expect(task.errors.full_messages.first).to match("#{I18n.t('activerecord.attributes.task.title')} #{I18n.t('activerecord.errors.models.task.attributes.title.blank')}")
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Task, type: :model do
+  before(:each) do
+    @task = Task.new
+  end
+
+  it "it contain title & content" do
+    @task.title
+    @task.content
+  end
+
+  it "is not valid without a title" do
+    @task.title = nil
+    expect(@task).to_not be_valid
+  end
+
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,18 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  before(:each) do
-    @task = Task.new
+  let(:task) { create(:task) }
+
+  before do
+    task
   end
 
   it "it contain title & content" do
-    @task.title
-    @task.content
+    task.title
+    task.content
   end
 
   it "is not valid without a title" do
-    @task.title = nil
-    expect(@task).to_not be_valid
+    task.title = nil
+    expect(task).to_not be_valid
   end
-
 end


### PR DESCRIPTION
針對任務的標題欄位新增不可為空的的資料驗證
- 新增任務標題不可為空的migration檔案，設定資料庫限制
- 在頁面上加入驗證的錯誤訊息
- 撰寫對應的 model 測試
- 調整驗證有錯誤後會新增div標籤(field_with_errors)造成資料被換行的問題
